### PR TITLE
V1.1.0 Release merge

### DIFF
--- a/README.html
+++ b/README.html
@@ -404,7 +404,7 @@ does support blocks as described in the bed spec.</strong></p>
 <tr>
 <td>cm_sumTypes</td>
 <td>"GT"</td>
-<td>How to calculate OVERALL and GENE blocks for countmuts output.</td>
+<td>How to calculate OVERALL and GENE blocks for countmuts output. The first character controls summing for overall: G -&gt; OVERALL = sum(GENEs); B -&gt; OVERALL = sum(BLOCKs).  In sum(GENEs) mode, this will ignore BLOCKs for the purposes of calculating OVERALL.  The second character controls summing for each GENE: T -&gt; GENE = Whole gene, ignoring BLOCKs; B -&gt; GENE = sum(BLOCKs).</td>
 </tr>
 <tr>
 <td>runSSCS</td>
@@ -413,7 +413,7 @@ does support blocks as described in the bed spec.</strong></p>
 </tr>
 <tr>
 <td>recovery</td>
-<td>"noRecovery.sh"</td>
+<td>"noRecovery_noSynLink.sh"</td>
 <td>The recovery script to use in attempting to recover ambiguously mapped reads (as determine by blast alignment vs bwa alignment).  Recovery script creation is discussed in 8; below.</td>
 </tr>
 </tbody>

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ Use the ConfigTemplate to create a new file with the appropriate headers.  For e
 | minDepth         | 100             | The minimum depth to use for count_muts generation |
 | maxNs            | 1               | The maximum proportion of N bases to use for count_muts generation |
 | cm_outputs       | "GB"            | Select which sections of the countmuts to output, in addition to 'OVERALL'.  String of one or more of 'G', 'B', and 'N'.  G -> output GENE sections for each bed line; B -> output 'BLOCK' sections for each block in the bed line (if present); 'N' -> Only output overall frequencies.  Overrides all other options. |  
-| cm_sumTypes      | "GT"            | How to calculate OVERALL and GENE blocks for countmuts output. |
+| cm_sumTypes      | "GT"            | How to calculate OVERALL and GENE blocks for countmuts output. The first character controls summing for overall: G -> OVERALL = sum(GENEs); B -> OVERALL = sum(BLOCKs).  In sum(GENEs) mode, this will ignore BLOCKs for the purposes of calculating OVERALL.  The second character controls summing for each GENE: T -> GENE = Whole gene, ignoring BLOCKs; B -> GENE = sum(BLOCKs).  |
 | runSSCS          | false           | true or false; whether to do full analysis for SSCS data.  | 
-| recovery         | "noRecovery.sh" | The recovery script to use in attempting to recover ambiguously mapped reads (as determine by blast alignment vs bwa alignment).  Recovery script creation is discussed in 8; below.  |  
+| recovery         | "noRecovery_noSynLink.sh" | The recovery script to use in attempting to recover ambiguously mapped reads (as determine by blast alignment vs bwa alignment).  Recovery script creation is discussed in 8; below.  |  
 
 Save the file as a .csv file with unix line endings (LF).
 

--- a/Snakefile
+++ b/Snakefile
@@ -179,7 +179,7 @@ def getDepthFiles():
         outList.append(
             f"{samples.loc[sampIter,'baseDir']}/"
             f"Stats/plots/"
-            f"{sampIter}.dcs.targetCoverage.tiff"
+            f"{sampIter}.dcs.targetCoverage.png"
             )
     return(outList)
 
@@ -189,7 +189,7 @@ def getInsertFiles():
         outList.append(
             f"{samples.loc[sampIter,'baseDir']}/"
             f"Stats/plots/"
-            f"{sampIter}.dcs.iSize_Histogram.tiff"
+            f"{sampIter}.dcs.iSize_Histogram.png"
             )
     return(outList)
 
@@ -230,7 +230,7 @@ def getReportInput(wildcards):
     #'Clipping Stats files
     #'Mutations Stats Files
     #'Final stats files
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.png')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs_BasePerPosInclNs.png')
@@ -245,10 +245,9 @@ def getReportInput(wildcards):
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/sscs/{wildcards.sample}.sscs.final.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam.bai')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.tiff')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.png')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.countmuts.csv')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/data/{wildcards.sample}.dcs_ambiguity_counts.txt')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
     return(outArgs)
 
 def getReportInput_noBlast(wildcards):
@@ -267,7 +266,7 @@ def getReportInput_noBlast(wildcards):
     #'Clipping Stats files
     #'Mutations Stats Files
     #'Final stats files
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.png')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs_BasePerPosInclNs.png')
@@ -278,9 +277,8 @@ def getReportInput_noBlast(wildcards):
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/sscs/{wildcards.sample}.sscs.final.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam.bai')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.tiff')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.png')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.countmuts.csv')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
     return(outArgs)
 
 
@@ -1303,7 +1301,6 @@ rule makeCountMuts:
         cd ..
         """
 
-
 rule InsertSize:
     params:
         sample = get_sample,
@@ -1352,7 +1349,7 @@ rule PlotInsertSize:
     input:
         "{runPath}/Stats/data/{sample}.{sampType}.iSize_Metrics.txt",
     output:
-        "{runPath}/Stats/plots/{sample}.{sampType}.iSize_Histogram.tiff"
+        temp("{runPath}/Stats/plots/{sample}.{sampType}.iSize_Histogram.tiff")
     conda:
         "envs/DS_env_full.yaml"
     shell:
@@ -1371,7 +1368,7 @@ rule PlotCoverage:
         inDepth = "{runPath}/Stats/data/{sample}.{sampType}.region.mutpos.vcf_depth.txt",
         inVCF = "{runPath}/Final/{sampType}/{sample}.{sampType}.vcf"
     output:
-        "{runPath}/Stats/plots/{sample}.{sampType}.targetCoverage.tiff"
+        temp("{runPath}/Stats/plots/{sample}.{sampType}.targetCoverage.tiff")
     conda:
         "envs/DS_env_full.yaml"
     log:
@@ -1492,6 +1489,22 @@ rule makeFileList:
         with open(output.outFileList, 'w') as outF:
             for samp in params.samples:
                 outF.write(f"{samp}\n")
+
+rule tiff2png:
+    params:
+        basePath = sys.path[0],
+    input:
+        "{prefix}.tiff"
+    output:
+        "{prefix}.png"
+    conda:
+        "envs/DS_env_full.yaml"
+    shell:
+        """
+        python {params.basePath}/scripts/tiff2png.py \
+        {wildcards.prefix}.tiff \
+        {wildcards.prefix}.png
+        """
 
 rule makeSummaryCSV:
     params:
@@ -1799,7 +1812,7 @@ import numpy as np
             # ~ f'IFrame(f"{wildcards.sample}.dcs.iSize_Histogram.pdf",600,600)\n'
             # ~ ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.tiff")'
+            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.png")'
             ))
 
         # Depth statistics
@@ -1808,7 +1821,7 @@ import numpy as np
             f"[Top](#Duplex-Sequencing-Summary)  \n"
             ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.tiff")'
+            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.png")'
             ))
 
         # Muts per read pos statistics
@@ -2085,7 +2098,7 @@ import numpy as np
             # ~ f'IFrame(f"{wildcards.sample}.dcs.iSize_Histogram.pdf",600,600)\n'
             # ~ ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.tiff")'
+            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.png")'
             ))
 
         # Depth statistics
@@ -2094,7 +2107,7 @@ import numpy as np
             f"[Top](#Duplex-Sequencing-Summary)  \n"
             ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.tiff")'
+            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.png")'
             ))
 
         # Muts per read pos statistics

--- a/Snakefile
+++ b/Snakefile
@@ -675,7 +675,7 @@ rule getFlagstats:
         cd ../
         """
 
-# Do nieve variant calling to allow us to not include reads that just have 
+# Do naive variant calling to allow us to not include reads that just have 
 # SNPs in them.  
 rule PreBlastProcessing1:
     params:
@@ -704,7 +704,7 @@ rule PreBlastProcessing1:
         cd ../
         """
 
-# Get SNPs from nieve variant calling
+# Get SNPs from naive variant calling
 rule PreBlastProcessing2:
     params:
         basePath = sys.path[0]
@@ -729,7 +729,7 @@ rule PreBlastProcessing2:
         cd ../
         """
 
-# Seperate out reads with non-SNP variants for examination with BLAST
+# Separate out reads with non-SNP variants for examination with BLAST
 rule PreBlastProcessing3:
     params:
         basePath = sys.path[0],
@@ -824,7 +824,7 @@ rule PostBlastProcessing1:
 # Multi-step process.  
 # 1. Merge species-labeled and unblasted reads into a single bam file
 # 2. Sort reads based on read name
-# 3. Filter out incorect species reads
+# 3. Filter out incorrect species reads
 # 4. Sort all outputs into position sorting
 rule PostBlastProcessing2:
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -179,7 +179,7 @@ def getDepthFiles():
         outList.append(
             f"{samples.loc[sampIter,'baseDir']}/"
             f"Stats/plots/"
-            f"{sampIter}.dcs.targetCoverage.png"
+            f"{sampIter}.dcs.targetCoverage.tiff"
             )
     return(outList)
 
@@ -189,7 +189,7 @@ def getInsertFiles():
         outList.append(
             f"{samples.loc[sampIter,'baseDir']}/"
             f"Stats/plots/"
-            f"{sampIter}.dcs.iSize_Histogram.png"
+            f"{sampIter}.dcs.iSize_Histogram.tiff"
             )
     return(outList)
 
@@ -230,7 +230,7 @@ def getReportInput(wildcards):
     #'Clipping Stats files
     #'Mutations Stats Files
     #'Final stats files
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.png')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs_BasePerPosInclNs.png')
@@ -245,10 +245,10 @@ def getReportInput(wildcards):
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/sscs/{wildcards.sample}.sscs.final.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam.bai')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.png')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.tiff')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.countmuts.csv')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/data/{wildcards.sample}.dcs_ambiguity_counts.txt')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.png')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
     return(outArgs)
 
 def getReportInput_noBlast(wildcards):
@@ -267,7 +267,7 @@ def getReportInput_noBlast(wildcards):
     #'Clipping Stats files
     #'Mutations Stats Files
     #'Final stats files
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.png')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.mutated.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs_BasePerPosInclNs.png')
@@ -278,9 +278,9 @@ def getReportInput_noBlast(wildcards):
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/sscs/{wildcards.sample}.sscs.final.bam.bai')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.final.bam.bai')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.png')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.targetCoverage.tiff')
     outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Final/dcs/{wildcards.sample}.dcs.countmuts.csv')
-    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.png')
+    outArgs.append(f'{samples.loc[(wildcards.sample),"baseDir"]}/Stats/plots/{wildcards.sample}.dcs.iSize_Histogram.tiff')
     return(outArgs)
 
 
@@ -1352,7 +1352,7 @@ rule PlotInsertSize:
     input:
         "{runPath}/Stats/data/{sample}.{sampType}.iSize_Metrics.txt",
     output:
-        "{runPath}/Stats/plots/{sample}.{sampType}.iSize_Histogram.png"
+        "{runPath}/Stats/plots/{sample}.{sampType}.iSize_Histogram.tiff"
     conda:
         "envs/DS_env_full.yaml"
     shell:
@@ -1371,7 +1371,7 @@ rule PlotCoverage:
         inDepth = "{runPath}/Stats/data/{sample}.{sampType}.region.mutpos.vcf_depth.txt",
         inVCF = "{runPath}/Final/{sampType}/{sample}.{sampType}.vcf"
     output:
-        "{runPath}/Stats/plots/{sample}.{sampType}.targetCoverage.png"
+        "{runPath}/Stats/plots/{sample}.{sampType}.targetCoverage.tiff"
     conda:
         "envs/DS_env_full.yaml"
     log:
@@ -1799,7 +1799,7 @@ import numpy as np
             # ~ f'IFrame(f"{wildcards.sample}.dcs.iSize_Histogram.pdf",600,600)\n'
             # ~ ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.png")'
+            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.tiff")'
             ))
 
         # Depth statistics
@@ -1808,7 +1808,7 @@ import numpy as np
             f"[Top](#Duplex-Sequencing-Summary)  \n"
             ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.png")'
+            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.tiff")'
             ))
 
         # Muts per read pos statistics
@@ -2085,7 +2085,7 @@ import numpy as np
             # ~ f'IFrame(f"{wildcards.sample}.dcs.iSize_Histogram.pdf",600,600)\n'
             # ~ ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.png")'
+            f'Image(f"plots/{wildcards.sample}.dcs.iSize_Histogram.tiff")'
             ))
 
         # Depth statistics
@@ -2094,7 +2094,7 @@ import numpy as np
             f"[Top](#Duplex-Sequencing-Summary)  \n"
             ))
         myCells.append(nbf.v4.new_code_cell(
-            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.png")'
+            f'Image(f"plots/{wildcards.sample}.dcs.targetCoverage.tiff")'
             ))
 
         # Muts per read pos statistics

--- a/Snakefile
+++ b/Snakefile
@@ -317,6 +317,7 @@ wildcard_constraints:
     sampType="(sscs)|(dcs)",
     sample="|".join([f"({x})" for x in samples.index])
 
+# Run all steps of the pipeline
 rule all:
     input:
         f"{config['samples']}.summary.csv", 
@@ -346,6 +347,8 @@ rule rerun:
         rm .rerunPrepDone
         """
 
+# Environment set up rules
+# Implemented to save time at run-time on environment setup
 rule initializeEnvs:
     input:
         "full.initialized"
@@ -437,6 +440,7 @@ rule initialize fgbio_env:
         touch fgbio.initialized
         """
 
+# Setup output directories
 rule makeDirs:
     output:
         outConfigTmp = temp(touch("{runPath}/.{sample}_dirsMade")), 
@@ -447,6 +451,7 @@ rule makeDirs:
         cd ../
         """
 
+# Make consensus sequences from input fastqs
 rule makeConsensus:
     params:
         sample = get_sample,
@@ -515,6 +520,7 @@ rule makeConsensus:
         cd ../
         """
 
+# Calculate # on target raw reads based on outAln1 and outAln2 from makeConsensus
 rule getOnTarget:
     params:
         basePath = sys.path[0],
@@ -554,6 +560,7 @@ rule getOnTarget:
         cd ../
         """
 
+# Align SSCS and DCS to provided reference genome, and sort based on position
 rule alignReads:
     params:
         sample = get_sample,
@@ -596,6 +603,7 @@ rule alignReads:
         cd ../
         """
 
+# Filter out secondary and supplamentery alignments prior to BLAST filters.
 rule PreBlastFilter:
     input:
         inBam="{runPath}/{sample}_mem.dcs.sort.bam",
@@ -622,6 +630,7 @@ rule PreBlastFilter:
         cd ../
         """
 
+# Make bam index for temporary bam files
 rule makeTempBai:
     input:
         inBam = "{runPath}/{fileBase}.temp.bam"
@@ -635,6 +644,7 @@ rule makeTempBai:
         samtools index {input.inBam} {output.outBai}
         """
 
+# make bam index for non-temporary bam files
 rule makeBai:
     input:
         inBam = "{runPath}/{fileBase}.bam"
@@ -648,6 +658,7 @@ rule makeBai:
         samtools index {input.inBam} {output.outBai}
         """
 
+# Get samtools flagstat output for a bam file
 rule getFlagstats:
     input:
         inBam = "{runPath}/{fileBase}.bam"
@@ -664,6 +675,8 @@ rule getFlagstats:
         cd ../
         """
 
+# Do nieve variant calling to allow us to not include reads that just have 
+# SNPs in them.  
 rule PreBlastProcessing1:
     params:
         basePath = sys.path[0],
@@ -691,6 +704,7 @@ rule PreBlastProcessing1:
         cd ../
         """
 
+# Get SNPs from nieve variant calling
 rule PreBlastProcessing2:
     params:
         basePath = sys.path[0]
@@ -715,6 +729,7 @@ rule PreBlastProcessing2:
         cd ../
         """
 
+# Seperate out reads with non-SNP variants for examination with BLAST
 rule PreBlastProcessing3:
     params:
         basePath = sys.path[0],
@@ -749,6 +764,7 @@ rule PreBlastProcessing3:
         cd ../
         """
 
+# BLAST reads with non-SNP variants
 rule BLAST:
     params:
         basePath = sys.path[0],
@@ -781,6 +797,7 @@ rule BLAST:
         cd ../
         """
 
+# Label reads with taxIDs based on BLAST results
 rule PostBlastProcessing1:
     params:
         basePath = sys.path[0]
@@ -804,7 +821,11 @@ rule PostBlastProcessing1:
         {wildcards.sample}_dcs
         cd ../
         """
-
+# Multi-step process.  
+# 1. Merge species-labeled and unblasted reads into a single bam file
+# 2. Sort reads based on read name
+# 3. Filter out incorect species reads
+# 4. Sort all outputs into position sorting
 rule PostBlastProcessing2:
     params:
         basePath = sys.path[0],
@@ -858,6 +879,7 @@ rule PostBlastProcessing2:
         cd ../
         """
 
+# Run user-defined recovery script
 rule postBlastRecovery:
     params:
         basePath = sys.path[0],
@@ -884,6 +906,8 @@ rule postBlastRecovery:
         cd ../
         """
 
+# Count number of reads in files after post-blast recovery with different 
+# ambiguity scores
 rule CountAmbig:
     params:
         basePath = sys.path[0],
@@ -904,6 +928,7 @@ rule CountAmbig:
         cd ../
         """
 
+# Apply fixed end clipping to SSCS (with no BLAST)
 rule endClipSscs:
     params:
         sample = get_sample,
@@ -946,6 +971,7 @@ rule endClipSscs:
         fi
         """
 
+# Apply fixed end clipping to DCS (with BLAST)
 rule endClipDcs:
     params:
         sample = get_sample,
@@ -989,6 +1015,7 @@ rule endClipDcs:
         fi
         """
 
+# Apply fixed end clipping to DCS (with no BLAST)
 rule endClipDcs_noBlast:
     params:
         sample = get_sample,
@@ -1031,6 +1058,7 @@ rule endClipDcs_noBlast:
         fi
         """
 
+# Run GATK3-based local realignment
 rule localRealign:
     params:
         sample = get_sample,
@@ -1068,6 +1096,7 @@ rule localRealign:
         cd ../
         """
 
+# Clip overlapping reads
 rule overlapClip:
     params:
         sample = get_sample,
@@ -1098,6 +1127,7 @@ rule overlapClip:
         cd ../
         """
 
+# Filter reads to only reads that overlap the provided bed file
 rule FinalFilter:
     params:
         runPath = get_baseDir,
@@ -1125,42 +1155,7 @@ rule FinalFilter:
         cd ../
         """
 
-rule pileup:
-    params:
-        sample = get_sample,
-        basePath = sys.path[0],
-        runPath = get_baseDir
-    input:
-        inBam = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam",
-        inBai = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam.bai",
-        inRef = get_reference,
-        inBed = get_target_bed
-    output:
-        outPile1 = temp("{runPath}/{sample}.{sampType}.filt.no_overlap.pileup"),
-        outPile2 = temp("{runPath}/{sample}.{sampType}.filt.no_overlap.region.pileup")
-    conda:
-        "envs/DS_env_full.yaml"
-    log:
-         "{runPath}/logs/{sample}_pileup_{sampType}.log"
-    shell:
-        """
-        cd {params.runPath}
-        samtools mpileup\
-        -B \
-        -A \
-        -d 500000 \
-        -Q 0 \
-        -f {input.inRef} \
-        ../{input.inBam} \
-        > ../{output.outPile1}
-        python {params.basePath}/scripts/filter_pileup.py \
-        {input.inBed} \
-        ../{output.outPile1} \
-        ../{output.outPile2} \
-        N
-        cd ../
-        """
-
+# Create VCF output
 rule makeVCF:
     params:
         basePath = sys.path[0],
@@ -1190,6 +1185,7 @@ rule makeVCF:
         cd ..
         """
 
+# get SNPs from VCF
 rule getSnps:
     params:
         basePath = sys.path[0],
@@ -1213,6 +1209,7 @@ rule getSnps:
         cd ..
         """
 
+# filter VCF to only variants covered by the provided bed file
 rule positionFilterVCF:
     params:
         runPath = get_baseDir,
@@ -1235,7 +1232,8 @@ rule positionFilterVCF:
         Final/{wildcards.sampType}/{wildcards.sample}.{wildcards.sampType}.region.Marked.mutpos.vcf
         cd ..
         """
-        
+
+# filter SNPs VCF to only SNPs covered by the provided bed file
 rule positionFilterSnpsVCF:
     params:
         runPath = get_baseDir,
@@ -1259,6 +1257,7 @@ rule positionFilterSnpsVCF:
         cd ..
         """
 
+# Make countMuts file from VCF file
 rule makeCountMuts:
     params:
         basePath = sys.path[0],
@@ -1301,6 +1300,7 @@ rule makeCountMuts:
         cd ..
         """
 
+# Collect insert size data
 rule InsertSize:
     params:
         sample = get_sample,
@@ -1342,7 +1342,8 @@ rule InsertSize:
         TMP_DIR=picardTempDir
         cd ../
         """
-        
+
+# Create insert size plot
 rule PlotInsertSize:
     params:
         basePath = sys.path[0],
@@ -1360,6 +1361,7 @@ rule PlotInsertSize:
         cd ..
         """
 
+# Create coverage plot
 rule PlotCoverage:
     params:
         basePath = sys.path[0],
@@ -1383,6 +1385,7 @@ rule PlotCoverage:
         cd ..
         """
 
+# Plot number of non-SNP variants per sequencing cycle
 rule MutsPerCycle:
     params:
         sample = get_sample,
@@ -1421,6 +1424,8 @@ rule MutsPerCycle:
         cd ../
         """
 
+# make config file for making summary CSV
+# This step will be removed in the future
 rule makeConfigRecord:
     params:
         sample = get_sample,
@@ -1480,6 +1485,8 @@ rule makeConfigRecord:
                 f"maxNs={params.maxNs}\n"
                 )
 
+# Make file list for making summary CSV file
+# this step will be removed in the future
 rule makeFileList:
     params:
         samples=samples.loc[:,"baseDir"]
@@ -1490,6 +1497,11 @@ rule makeFileList:
             for samp in params.samples:
                 outF.write(f"{samp}\n")
 
+# Convert TIFF figures created by R into PNG figures
+# We implemented this due to artifacts in the raw PNG output produced by
+# R, and a desire to embed the resulting figures in the report html file.
+# This issue may be revisited in the future, if we come accross a better 
+# PNG device for R.  
 rule tiff2png:
     params:
         basePath = sys.path[0],
@@ -1506,6 +1518,7 @@ rule tiff2png:
         {wildcards.prefix}.png
         """
 
+# make summary files
 rule makeSummaryCSV:
     params:
         basePath = sys.path[0],
@@ -1587,6 +1600,7 @@ rule makeSummaryFamilySize:
         {params.configPath}
         """
 
+# make per-sample report file (with BLAST)
 rule makeReport:
     params:
         sample = get_sample,
@@ -1890,6 +1904,7 @@ import numpy as np
         nb['cells'] = myCells
         nbf.write(nb, f"{wildcards.runPath}/Stats/{wildcards.sample}.report.ipynb")
 
+# make per-sample report file (without BLAST)
 rule makeReport_noBlast:
     params:
         sample = get_sample,
@@ -2176,6 +2191,7 @@ import numpy as np
         nb['cells'] = myCells
         nbf.write(nb, f"{wildcards.runPath}/Stats/{wildcards.sample}.report.ipynb")
 
+# Compile report ipython notebook
 rule compileReport:
     input:
         "{runPath}/Stats/{sample}.report.ipynb"
@@ -2191,6 +2207,7 @@ rule compileReport:
         cd ../../
         """
 
+# Ruleorders
 ruleorder: alignReads > makeBai
 ruleorder: PreBlastFilter > makeBai
 ruleorder: PreBlastProcessing1 > makeBai

--- a/scripts/MakeDepthPlot.R
+++ b/scripts/MakeDepthPlot.R
@@ -71,10 +71,16 @@ if (length(row.names(depth)) > 0) {
     maxNs = 1
     depth$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
 }
+if (maxNs == 0) {
+  maxNs = 1
+}
+if (maxDP == 0) {
+  maxDP = 1
+}
 multiplier = -maxDP / maxNs
 
 
-myFName = paste("Final/",inSampType,"/",inSampName, ".vcf", sep="")
+#myFName = paste("Final/",inSampType,"/",inSampName, ".vcf", sep="")
 myVCF <- read_delim(
   myFName, "\t", 
   escape_double = FALSE, 
@@ -98,8 +104,8 @@ for (dataIter in seq(1,length(row.names(myVCF)))) {
 myVCF$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
 } else {myVCF$Target = factor()}
 myPlot=ggplot(data = depth[depth$Target != "Off_Target",]) + 
-  geom_area(mapping = aes(x = Pos, y = DP), stat="identity") + 
-  geom_area(mapping=aes(x=Pos, y=Ns * multiplier), color='red', alpha=0.7) + 
+  geom_bar(mapping = aes(x = Pos, y = DP), stat="identity", width=1) + 
+  geom_bar(mapping=aes(x=Pos, y=Ns * multiplier), color='red', alpha=0.7, stat="identity", width=1) + 
   geom_segment(data = myBed, mapping = aes(x=Start,xend=End, y=0, yend=0))
 if (length(row.names(myVCF)) > 0) {
   myPlot = myPlot + 
@@ -116,6 +122,7 @@ myPlot = myPlot +
     axis.text.x = element_text(angle=90)
   ) + 
   facet_wrap(. ~ Target, scales = "free_x", ncol = min(length(myBed$Name), 4))
+myPlot
 ggsave(filename = paste("Stats/plots/", inSampName, ".targetCoverage.png", sep=""), 
        plot=myPlot, 
        width = 200, 

--- a/scripts/MakeDepthPlot.R
+++ b/scripts/MakeDepthPlot.R
@@ -48,28 +48,28 @@ myBed$End <- myBed$End + 1
 myBed$Target = factor(myBed$Name, levels = c(myBed$Name,"Off_Target"))
 namesVect = c()
 if (length(row.names(depth)) > 0) {
-    for (dataIter in seq(1,length(row.names(depth)))) {
-      myName = "Off_Target"
-      for (bedIter in seq(1, length(row.names(myBed)))) {
-        if ( depth$`#Chrom`[dataIter] == myBed$Chrom[bedIter] && 
-             depth$Pos[dataIter] >= myBed$Start[bedIter] && 
-             depth$Pos[dataIter] < myBed$End[bedIter]) {
-          myName = myBed$Name[bedIter]
-          break
-        }
+  for (dataIter in seq(1,length(row.names(depth)))) {
+    myName = "Off_Target"
+    for (bedIter in seq(1, length(row.names(myBed)))) {
+      if ( depth$`#Chrom`[dataIter] == myBed$Chrom[bedIter] && 
+           depth$Pos[dataIter] >= myBed$Start[bedIter] && 
+           depth$Pos[dataIter] < myBed$End[bedIter]) {
+        myName = myBed$Name[bedIter]
+        break
       }
-      namesVect = c(namesVect, myName)
     }
-    maxDP = max(depth$DP)
-    depth$Nfract = depth$Ns / depth$DP * 100
-    depth$Nfract[depth$DP == 0] = 0
-    depth$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
-    maxNs = ceiling(max(depth$Ns[depth$Target != "Off_Target"])/3)*3
-    
+    namesVect = c(namesVect, myName)
+  }
+  maxDP = max(depth$DP)
+  depth$Nfract = depth$Ns / depth$DP * 100
+  depth$Nfract[depth$DP == 0] = 0
+  depth$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
+  maxNs = ceiling(max(depth$Ns[depth$Target != "Off_Target"])/3)*3
+  
 } else {
-    maxDP = 1
-    maxNs = 1
-    depth$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
+  maxDP = 1
+  maxNs = 1
+  depth$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
 }
 if (maxNs == 0) {
   maxNs = 1
@@ -80,28 +80,28 @@ if (maxDP == 0) {
 multiplier = -maxDP / maxNs
 
 
-#myFName = paste("Final/",inSampType,"/",inSampName, ".vcf", sep="")
+myFName = paste("Final/",inSampType,"/",inSampName, ".vcf", sep="")
 myVCF <- read_delim(
   myFName, "\t", 
   escape_double = FALSE, 
   comment = "##", 
   trim_ws = TRUE
-  )
+)
 namesVect = c()
 if (length(row.names(myVCF)) > 0) {
-for (dataIter in seq(1,length(row.names(myVCF)))) {
-  myName = "Off_Target"
-  for (bedIter in seq(1, length(row.names(myBed)))) {
-    if ( myVCF$`#CHROM`[dataIter] == myBed$Chrom[bedIter] && 
-         myVCF$POS[dataIter] >= myBed$Start[bedIter] && 
-         myVCF$POS[dataIter] < myBed$End[bedIter]) {
-      myName = myBed$Name[bedIter]
-      break
+  for (dataIter in seq(1,length(row.names(myVCF)))) {
+    myName = "Off_Target"
+    for (bedIter in seq(1, length(row.names(myBed)))) {
+      if ( myVCF$`#CHROM`[dataIter] == myBed$Chrom[bedIter] && 
+           myVCF$POS[dataIter] >= myBed$Start[bedIter] && 
+           myVCF$POS[dataIter] < myBed$End[bedIter]) {
+        myName = myBed$Name[bedIter]
+        break
+      }
     }
+    namesVect = c(namesVect, myName)
   }
-  namesVect = c(namesVect, myName)
-}
-myVCF$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
+  myVCF$Target = factor(namesVect, levels = c(myBed$Name,"Off_Target"))
 } else {myVCF$Target = factor()}
 myPlot=ggplot(data = depth[depth$Target != "Off_Target",]) + 
   geom_bar(mapping = aes(x = Pos, y = DP), stat="identity", width=1) + 
@@ -109,7 +109,7 @@ myPlot=ggplot(data = depth[depth$Target != "Off_Target",]) +
   geom_segment(data = myBed, mapping = aes(x=Start,xend=End, y=0, yend=0))
 if (length(row.names(myVCF)) > 0) {
   myPlot = myPlot + 
-  geom_point(data=myVCF[myVCF$Target != "Off_Target",], mapping=aes(x=POS, y=maxDP), shape=1)
+    geom_point(data=myVCF[myVCF$Target != "Off_Target",], mapping=aes(x=POS, y=maxDP), shape=1)
 }
 myPlot = myPlot + 
   scale_y_continuous(
@@ -122,10 +122,10 @@ myPlot = myPlot +
     axis.text.x = element_text(angle=90)
   ) + 
   facet_wrap(. ~ Target, scales = "free_x", ncol = min(length(myBed$Name), 4))
-myPlot
-ggsave(filename = paste("Stats/plots/", inSampName, ".targetCoverage.png", sep=""), 
+ggsave(filename = paste("Stats/plots/", inSampName, ".targetCoverage.tiff", sep=""), 
        plot=myPlot, 
        width = 200, 
        height=50*ceiling(length(levels(depth$Target)) / 4), 
        units="mm", 
-       device = "png")
+       device = "tiff", 
+       compression="lzw")

--- a/scripts/MakeDepthPlot.R
+++ b/scripts/MakeDepthPlot.R
@@ -20,29 +20,10 @@ depth <- read_delim(myFName,
                     "\t", escape_double = FALSE, trim_ws = TRUE, 
                     col_types="cicii") 
 # Set column names
+bedColNames = c("Chrom","Start","End", "Name","Score","Strand","thickStart","thickEnd","itemRgb","blockCounts","blockSizes","blockStarts")
 numCols = length(colnames(myBed))
-if (numCols == 3) {
-  colnames(myBed) <- c("Chrom","Start","End")
-  myBed$Name = row.names(myBed)
-} else if (numCols == 4) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name")
-} else if (numCols == 5) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score")
-} else if (numCols == 6) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand")
-} else if (numCols == 7) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand","thickStart")
-} else if (numCols == 8) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand","thickStart","thickEnd")
-} else if (numCols == 9) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand","thickStart","thickEnd","itemRgb")
-} else if (numCols == 10) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand","thickStart","thickEnd","itemRgb","blockCounts")
-}  else if (numCols == 11) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand","thickStart","thickEnd","itemRgb","blockCounts","blockSizes")
-} else if (numCols == 12) {
-  colnames(myBed) <- c("Chrom","Start","End", "Name","Score","Strand","thickStart","thickEnd","itemRgb","blockCounts","blockSizes","blockStarts")
-} 
+colnames(myBed) <- bedColNames[1:numCols]
+
 myBed$Start <- myBed$Start + 1
 myBed$End <- myBed$End + 1
 myBed$Target = factor(myBed$Name, levels = c(myBed$Name,"Off_Target"))

--- a/scripts/plotInsertSize.R
+++ b/scripts/plotInsertSize.R
@@ -35,6 +35,7 @@ myPlot = ggplot(data=myInsertSizes, mapping = aes(x=insert_size)) +
   scale_y_continuous(sec.axis = sec_axis(~./max(myInsertSizes$All_Reads.fr_count), name="Cumulative Proportion")) + 
   theme_bw()
 ggsave(
-  filename=paste("Stats/plots/", inSampName, ".iSize_Histogram.png", sep=""), 
-  plot=myPlot, height=6, width=6, units="in"
+  filename=paste("Stats/plots/", inSampName, ".iSize_Histogram.tiff", sep=""), 
+  plot=myPlot, height=6, width=6, units="in", 
+  device = "tiff", compression="lzw"
   )

--- a/scripts/plotSummaryDepth.py
+++ b/scripts/plotSummaryDepth.py
@@ -10,6 +10,6 @@ samples = pd.read_csv(o.config).set_index("sample", drop=False)
 
 myImages = []
 for sampIter in samples.index:
-    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.targetCoverage.png').convert('RGB'))
+    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.targetCoverage.tiff').convert('RGB'))
 
 myImages[0].save(f'{o.config}.summaryDepth.pdf', save_all=True, append_images=myImages[1:])

--- a/scripts/plotSummaryDepth.py
+++ b/scripts/plotSummaryDepth.py
@@ -10,6 +10,6 @@ samples = pd.read_csv(o.config).set_index("sample", drop=False)
 
 myImages = []
 for sampIter in samples.index:
-    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.targetCoverage.tiff').convert('RGB'))
+    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.targetCoverage.png').convert('RGB'))
 
 myImages[0].save(f'{o.config}.summaryDepth.pdf', save_all=True, append_images=myImages[1:])

--- a/scripts/plotSummaryInsertSize.py
+++ b/scripts/plotSummaryInsertSize.py
@@ -10,6 +10,6 @@ samples = pd.read_csv(o.config).set_index("sample", drop=False)
 
 myImages = []
 for sampIter in samples.index:
-    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.iSize_Histogram.png').convert('RGB'))
+    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.iSize_Histogram.tiff').convert('RGB'))
 
 myImages[0].save(f'{o.config}.summaryInsertSize.pdf', save_all=True, append_images=myImages[1:])

--- a/scripts/plotSummaryInsertSize.py
+++ b/scripts/plotSummaryInsertSize.py
@@ -10,6 +10,6 @@ samples = pd.read_csv(o.config).set_index("sample", drop=False)
 
 myImages = []
 for sampIter in samples.index:
-    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.iSize_Histogram.tiff').convert('RGB'))
+    myImages.append(Image.open(f'{samples.loc[sampIter,"baseDir"]}/Stats/plots/{sampIter}.dcs.iSize_Histogram.png').convert('RGB'))
 
 myImages[0].save(f'{o.config}.summaryInsertSize.pdf', save_all=True, append_images=myImages[1:])

--- a/scripts/tiff2png.py
+++ b/scripts/tiff2png.py
@@ -1,0 +1,28 @@
+from PIL import Image
+from argparse import ArgumentParser, ArgumentTypeError
+
+def isPNG(fileName):
+    if fileName[-4:].upper() != '.PNG':
+        msg = f"{fileName} is not a PNG file"
+        raise ArgumentTypeError(msg)
+    return fileName
+
+def isTIFF(fileName):
+    if (
+            fileName[-5:].upper() != '.TIFF' 
+            and fileName[-4:].upper() != '.TIF'
+            ):
+        msg = f"{fileName} is not a TIFF file"
+        raise ArgumentTypeError(msg)
+    return fileName
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('inTiff', type=isTIFF)
+    parser.add_argument('outPng', type=isPNG)
+    o = parser.parse_args()
+    
+    Image.open(o.inTiff).save(o.outPng)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# CHANGELOG
## v1.1.0: 
### Bugfixes:
 * Add testConfig.csv file, which was accidentally omitted in the 1.0.0 release
 * Fix bug with depth plots where zero-depth positions could accidentally be labeled as having non-zero depth
 * Fix crashes from running samples that produce no DCS data
 * Change the default recovery script to avoid synlinks
### New Features: 
 * Additional output options for the bamToCountmuts program
    - Allow summing total and genes by gene or by block
    - Allow outputting all, overall + genes, overall + blocks, or just overall
 * Add VERSION file, and specify pipeline version in the report output.
 * Get mutation counts from the VCF file, instead of directly from the BAM file
 * Add ability to set maximum number of cores to use during setup.
### Internal changes:
 * Simplify bed file column naming in depth plotting script
 * Separate mutanal steps into different snakemake rules
 * General code cleanup