### PR TITLE
Add additional functionality to mutPerCycle

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1039,6 +1039,24 @@ rule FinalFilter:
         cd ../
         """
 
+rule makeBufferedBed:
+    params:
+        readLength = get_readLen,
+    input:
+        inBed = get_target_bed,
+        inRef = get_reference, 
+    output:
+        outBed = temp("{runPath}/{sample}.vardictBed.bed"),
+        temp_sizes = temp("{runPath}/{sample}.ref.genome"),
+    shell:
+        """
+        cd {wildcards.runPath}
+        cut -f 1,2 {input.inRef}.fai > {wildcards.sample}.ref.genome
+        bedtools slop -i {input.inBed} -g {wildcards.sample}.ref.genome \
+        -b {params.readLength} > {wildcards.sample}.vardictBed.bed
+        cd ../
+        """
+
 rule varDict:
     params:
         clip5 = get_clipBegin,
@@ -1056,7 +1074,7 @@ rule varDict:
     input:
         inBam = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam", 
         inBai = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam.bai",
-        inBed = get_target_bed,
+        inBed = "{runPath}/{sample}.vardictBed.bed",
         inRef = get_reference
     output:
         outVars = temp("{runPath}/{sample}.{sampType}.varDict.txt"), 
@@ -1073,7 +1091,7 @@ rule varDict:
         -N {params.sampName} \
         -r {params.vardict_r} \
         -v -c 1 -S 2 -E 3 -U -g 4 \
-        {input.inBed} \
+        {wildcards.sample}.vardictBed.bed \
         -h -V {params.vardict_V} \
         --adaptor {params.vardict_adaptor} \
         > {wildcards.sample}.{wildcards.sampType}.varDict.txt
@@ -1097,7 +1115,7 @@ rule varDict_Ns:
     input:
         inBam = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam", 
         inBai = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam.bai",
-        inBed = get_target_bed,
+        inBed = "{runPath}/{sample}.vardictBed.bed",
         inRef = get_reference
     output:
         outVars = temp("{runPath}/{sample}.{sampType}.varDict.Ns.txt"), 
@@ -1115,7 +1133,7 @@ rule varDict_Ns:
         -N {params.sampName} \
         -r {params.vardict_r} \
         -v -c 1 -S 2 -E 3 -U -g 4 \
-        {input.inBed} \
+        {wildcards.sample}.vardictBed.bed \
         -h -V {params.vardict_V} \
         --adaptor {params.vardict_adaptor} \
         > {wildcards.sample}.{wildcards.sampType}.varDict.Ns.txt

--- a/Snakefile
+++ b/Snakefile
@@ -91,6 +91,12 @@ def get_cleanup(wildcards):
     return samples.loc[wildcards.sample, "cleanup"]
 def get_recovery(wildcards):
     return f'{sys.path[0]}/scripts/RecoveryScripts/{samples.loc[wildcards.sample, "recovery"]}'
+
+def get_mpc_filters(wildcards):
+    out_str = " ".join([
+        f"--filter {x}" for x in samples.loc[wildcards.sample, "cm_filters"].split(':')])
+    return out_str
+
 def get_final_length(wildcards):
     myLen = int(samples.loc[wildcards.sample, "readLen"])
     myLen -= int(samples.loc[wildcards.sample, "umiLen"])
@@ -1218,6 +1224,7 @@ rule MutsPerCycle:
         basePath = sys.path[0],
         runPath = get_baseDir,
         readLength = get_final_length
+        filter_string = get_mpc_filters
     input:
         inRef = get_reference,
         inFinal = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam",
@@ -1241,7 +1248,8 @@ rule MutsPerCycle:
         --inFile Final/{wildcards.sampType}/{wildcards.sample}.{wildcards.sampType}.final.bam \
         --inSnps Final/{wildcards.sampType}/{wildcards.sample}.{wildcards.sampType}.snps.vcf \
         -o {wildcards.sample}.{wildcards.sampType} \
-        -l {params.readLength} -b -t 0 -c --text_file
+        -l {params.readLength} -b -t 0 -c --text_file \
+        --filter SNP --filter INDEL {params.filter_string}
         
         mv {wildcards.sample}.{wildcards.sampType}*.png Stats/plots/
         mv {wildcards.sample}.{wildcards.sampType}_MutsPerCycle.dat.csv Stats/data/

--- a/Snakefile
+++ b/Snakefile
@@ -1223,13 +1223,13 @@ rule MutsPerCycle:
         sample = get_sample,
         basePath = sys.path[0],
         runPath = get_baseDir,
-        readLength = get_final_length
+        readLength = get_final_length,
         filter_string = get_mpc_filters
     input:
         inRef = get_reference,
         inFinal = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam",
         inFinalBai = "{runPath}/Final/{sampType}/{sample}.{sampType}.final.bam.bai",
-        inSnps = "{runPath}/Final/{sampType}/{sample}.{sampType}.snps.vcf"
+        inSnps = "{runPath}/Final/{sampType}/{sample}.{sampType}.vcf"
     output:
         outBam2 = "{runPath}/Final/{sampType}/{sample}.{sampType}.mutated.bam",
         outErrPerCyc2_WN = "{runPath}/Stats/plots/{sample}.{sampType}_BasePerPosInclNs.png",
@@ -1246,7 +1246,7 @@ rule MutsPerCycle:
         cd {params.runPath}
         python3 {params.basePath}/scripts/countMutsPerCycle.py  \
         --inFile Final/{wildcards.sampType}/{wildcards.sample}.{wildcards.sampType}.final.bam \
-        --inSnps Final/{wildcards.sampType}/{wildcards.sample}.{wildcards.sampType}.snps.vcf \
+        --inVCF Final/{wildcards.sampType}/{wildcards.sample}.{wildcards.sampType}.vcf \
         -o {wildcards.sample}.{wildcards.sampType} \
         -l {params.readLength} -b -t 0 -c --text_file \
         --filter SNP --filter INDEL {params.filter_string}

--- a/envs/DS_env_full.yaml
+++ b/envs/DS_env_full.yaml
@@ -17,6 +17,7 @@ dependencies:
   - regex
   - biopython
   - blast
+  - bedtools
   - jupyterlab
   - nbconvert
   - pandoc

--- a/scripts/countMutsPerCycle.py
+++ b/scripts/countMutsPerCycle.py
@@ -15,7 +15,6 @@ compBase = {"C": "G", "G": "C", "T": "A", "A": "T", "N": "N"}
 
 class MismatchCounter:
     def __init__(self, max_read_length, filters, filterSet, indelsSet, varsSet):
-        o.rlen, o.filters, snps, indels, variants
         self.mismatch_counts = [
             {"C>T": 0, "C>A": 0, "C>G": 0, "T>A": 0, "T>C": 0, "T>G": 0, "C>N": 0, "T>N": 0, "Count": 0}
             for i in range(max_read_length)
@@ -25,6 +24,7 @@ class MismatchCounter:
         self.snps = filterSet
         self.indels = indelsSet
         self.vars = varsSet
+        self.debug_file = open("MPC_debug.txt",'w')
 
     def countRead(self, read):
         numMuts = 0
@@ -71,6 +71,7 @@ class MismatchCounter:
                         # remove non-included variants, if requested
                         use_variant = False
                     if use_variant:
+                        self.debug_file.write(f"{snpTest}\n")
                         if readDir == -1:
                             self.mismatch_counts[rLen - x[0] - hardclipping - 1][f"{refBase}>{readBase}"] += 1
                         elif readDir == 1:
@@ -159,7 +160,7 @@ def near_indel(inVar, inIndel):
     indelbins = inIndel.split(':')[:2]
     indel_start = int(indelbins[1]) - indel_length
     indel_stop = int(indelbins[1]) + indel_length
-    varbins = in_var.split(':')[:2]
+    varbins = inVar.split(':')[:2]
     if (
             varbins[0] == indelbins[0]
             and indel_start <= int(varbins[1]) <= indel_stop):
@@ -268,7 +269,7 @@ def main():
     o = parser.parse_args()
     # Get list of SNPs from snp file
     inVCF = VariantFile(o.inVCF, 'r')
-    filtOut = set()
+    filt_out = set()
     indels = set()
     variants = set()
     for line in inVCF:

--- a/scripts/countMutsPerCycle.py
+++ b/scripts/countMutsPerCycle.py
@@ -24,7 +24,7 @@ class MismatchCounter:
         self.snps = filterSet
         self.indels = indelsSet
         self.vars = varsSet
-        self.debug_file = open("MPC_debug.txt",'w')
+        #self.debug_file = open("MPC_debug.txt",'w')
 
     def countRead(self, read):
         numMuts = 0
@@ -71,7 +71,7 @@ class MismatchCounter:
                         # remove non-included variants, if requested
                         use_variant = False
                     if use_variant:
-                        self.debug_file.write(f"{snpTest}\n")
+                        #self.debug_file.write(f"{snpTest}\n")
                         if readDir == -1:
                             self.mismatch_counts[rLen - x[0] - hardclipping - 1][f"{refBase}>{readBase}"] += 1
                         elif readDir == 1:


### PR DESCRIPTION
Change countMutsPerCycle to allow filtering out mutatios based on VCF filters, and to allow for filtering of near indel variants.
Also allows for an "include" mode that includes only variants in the VCF file.

Modify Snakefile to allow this method to draw from the countmuts filtering parameters.